### PR TITLE
Clear out old cache storage for new deployments

### DIFF
--- a/apps/digital-www/public/sw.js
+++ b/apps/digital-www/public/sw.js
@@ -15,8 +15,21 @@ const cacheClone = async (e) => {
     console.log('service worker installed');
   });
 
-  self.addEventListener('activate', () => {
+  self.addEventListener('activate', (event) => {
     console.log('service worker activated');
+
+    event.waitUntil(
+      caches.keys().then((keyList) =>
+        Promise.all(
+          keyList.map((key) => {
+            if (key !== cacheName) {
+              console.log(`Clearing stale cache ${key}`);
+              return caches.delete(key);
+            }
+          })
+        )
+      )
+    );
   });
 
   self.addEventListener('fetch', (e) => {


### PR DESCRIPTION
## Description
Clearing out the old storage caches when updating to a new version ensures that cache storage size doesn't bloat over time, and makes sure we don't ever return stale resources from an old deployment.